### PR TITLE
Fixes for Py3 and Newer numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Creates four CMYK images and a combined image.  Provides options for haltoning o
 | OPTION 				 | DESCRIPTION                                     | Default | 
 | ---------------------- | ----------------------------------------------- | ------- | 
 | -h, --help             | show this help message and exit                 | n/a     | 
+| -l, --halftone         | halftone the image                              | False   | 
 | -b, --bits {1,2,4,6,8} | bits of color info per channel                  | 8       | 
 | -c, --colorize_CMYK    | save CMYK files as RGB color images             | False   | 
 | -d, --do_not_halftone	 | don't do halftoning                             | False   | 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Heavily adapted from [this StackOverflow answer][so] by [fraxel][fr] and [this c
 
     halftone.py [-h] [-a ANGLES [ANGLES ...]] [-b {1,2,4,6,8}] [-c] [-d]
                    [-e EXTRA_FILE_NAME] [-f FILL] [-g GRAY] [-p SHARPNESS]
-                   [-s SIZE]
+                   [-s SIZE] [-l]
                    file
 
 Creates four CMYK images and a combined image.  Provides options for haltoning or not (-d)

--- a/TiffWriter.py
+++ b/TiffWriter.py
@@ -47,7 +47,7 @@ def write_tiff(file_name, img, bit_depth=8, photometric=None, DPI=200):
         Affects: Writes over existing files without warning
     """
 
-    print file_name
+    print(file_name)
 
     if len(img.shape) == 1:
         height = 1

--- a/halftone.py
+++ b/halftone.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from PIL import Image
 import numpy as np
 from scipy.ndimage.interpolation import rotate
@@ -20,7 +18,8 @@ def crop_center(img, new_shape):
     """
     ul = ((img.shape[0]-new_shape[0])/2, (img.shape[1]-new_shape[1])/2)
     br = (ul[0]+new_shape[0], ul[1]+new_shape[1])
-    return img[ul[0]:br[0], ul[1]:br[1]]
+    #print(f"ul[0]= {ul[0]} : br[0]= {br[0]}, ul[1]= {ul[1]}: br[1]= {br[1]}")
+    return img[int(ul[0]):int(br[0]), int(ul[1]):int(br[1])]
 
 
 def gauss_kernel(size, sigma=None, size_y=None, sigma_y=None):
@@ -108,7 +107,10 @@ def halftone(cmyk, size, angles, fill, sharpness):
 
         # tile the kernel across the image
         num_kernels = np.array(rotated.shape) / s + 1
-        tiled_kernel = np.tile(kernel, num_kernels)
+        # print(f"kernel: {kernel} - num_kernels: {num_kernels}")
+        # print(f"kernel: {type(kernel)} - num_kernels: {type(num_kernels)}")
+        # print(num_kernels[1])
+        tiled_kernel = np.tile(kernel, (int(num_kernels[0]), int(num_kernels[1])))
         tiled_kernel = resize(tiled_kernel, rotated.shape)
 
         # multiply the kernel image with the weights to generate the halftone image
@@ -118,6 +120,7 @@ def halftone(cmyk, size, angles, fill, sharpness):
         halftone = rotate(halftone, -angle, prefilter=False, order=1)
 
         # crop the image to the original size
+        #print(f"channel.shape: {channel.shape}")
         halftone = crop_center(halftone, channel.shape)
 
         # add this chanel to the full cmyk image
@@ -205,7 +208,7 @@ if __name__ == '__main__':
     try:
         im = Image.open(args.file)
     except IOError:
-        print "Cannot open ", args.file
+        print("Cannot open ", args.file)
         exit(1)
 
     # convert to numpy array


### PR DESCRIPTION
This would resolve: #3

These changes allow the project to work under more modern systems and library versions. 

I also noticed that `-l` is missing from the readme, so I added that as well. 

I was able to get it working with these changes on Python 3.10 and numpy 1.24.3

It does not seem like this project is active, so I'm guessing this may never get merged, but hopefully it can help someone who is trying to get this working.